### PR TITLE
Update package.json license

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "webix",
     "jet"
   ],
-  "license": "GPL-3.0-only",
+  "license": "GPL-3.0-or-later",
   "devDependencies": {
     "@babel/core": "^7.14.3",
     "@babel/plugin-transform-modules-commonjs": "^7.14.0",


### PR DESCRIPTION
Based on the existing LICENSE file clause:
> This program is free software: you can redistribute it and/or modify
> it under the terms of the GNU General Public License as published by
> the Free Software Foundation, either version 3 of the License, or
> (at your option) any later version.

the appropriate SPDX license identifier is `GPL-3.0-or-later`.