### PR TITLE
Disable nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * *"
 jobs:
   test:
     name: Test production build


### PR DESCRIPTION
Failures will generally be fixed on a release schedule, so continual nightly failures just add noise.