### PR TITLE
Request zip download url using json body instead of form data

### DIFF
--- a/sources/services/ajaxActions.js
+++ b/sources/services/ajaxActions.js
@@ -224,7 +224,7 @@ class AjaxActions {
 			const headers = await getAuthHeaders();
 			const resp = await this._ajax()
 				.headers(headers)
-				.post(`${API_URL}zip-download/url/`, params);
+				.post(`${API_URL}zip-download/url/`, JSON.stringify(params));
 			const url = this._parseData(resp);
 			return url;
 		}


### PR DESCRIPTION
This is to accommodate a recent change on the API side.