### PR TITLE
Prevent CORS preflight of GET requests

### DIFF
--- a/sources/services/ajaxActions.js
+++ b/sources/services/ajaxActions.js
@@ -66,7 +66,6 @@ class AjaxActions {
 
 	async _ajaxGet(url, params) {
 		const headers = await getAuthHeaders();
-		headers["Content-Type"] = "application/json";
 		if (!params) {
 			params = {};
 		}


### PR DESCRIPTION
HTTP GET requests ideally shouldn't require CORS preflighting, which has the effect of doubling the effective latency of every request (as an OPTIONS request will be made prior to every request). Normally, GET requests don't require preflighting, but adding `Content-Type: application/json` triggers preflighting. See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests for a list of conditions which trigger preflighting.

GET requests have no body, so a `Content-Type` header is pointless anyway.