### PR TITLE
Update OAuth2 client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
-        "@isic/client": "^0.6.2",
+        "@resonant/oauth-client": "^1.0.2",
         "aws-sdk": "^2.910.0",
         "axios": "^1.6.1",
         "core-js": "^3.38.0",
@@ -2198,14 +2198,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@girder/oauth-client": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@girder/oauth-client/-/oauth-client-0.7.7.tgz",
-      "integrity": "sha512-BWkF4tAzUVWtw8p8KdVj7MAusgf2VO7LlhRSN0SVfCk4pTYqneT3S3wFoK1yqPKeiif4MalFT6YLpIygVicn5Q==",
-      "dependencies": {
-        "@openid/appauth": "^1.3.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -2225,14 +2217,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
-    },
-    "node_modules/@isic/client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@isic/client/-/client-0.6.2.tgz",
-      "integrity": "sha512-iuJ8A35i+rzagV7QJ8VA9k7LShr1m8U1zGCu1uL405ABHGuPH6K9YicYcOT+AECzpFFwvH5bQm6atEzlh2/djQ==",
-      "dependencies": {
-        "@girder/oauth-client": "^0.7.7"
-      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2976,22 +2960,24 @@
       }
     },
     "node_modules/@openid/appauth": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@openid/appauth/-/appauth-1.3.1.tgz",
-      "integrity": "sha512-e54kpi219wES2ijPzeHe1kMnT8VKH8YeTd1GAn9BzVBmutz3tBgcG1y8a4pziNr4vNjFnuD4W446Ua7ELnNDiA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@openid/appauth/-/appauth-1.3.2.tgz",
+      "integrity": "sha512-NoOejniaqzOEbHg3RcBZtTriYqhqpQFgTC4lDNaRbgRCnpz6n8PlxWlCbh2N1K5qKawfxRP29/Wiho3FrXQ3Qw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/base64-js": "^1.3.0",
-        "@types/jquery": "^3.5.5",
+        "@types/base64-js": "^1.3.2",
+        "@types/jquery": "^3.5.29",
         "base64-js": "^1.5.1",
-        "follow-redirects": "^1.13.3",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "opener": "^1.5.2"
       }
     },
     "node_modules/@openid/appauth/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2999,6 +2985,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@resonant/oauth-client": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@resonant/oauth-client/-/oauth-client-1.0.2.tgz",
+      "integrity": "sha512-P7mPkqtaUFGxK8Gb8oQXZHhvUGKgsxDzdnBgODUSoACwZj2uDmYrUIKEjnKoIYTlLLpeaxZE3yULl3RtJu0teg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openid/appauth": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3070,9 +3068,10 @@
       }
     },
     "node_modules/@types/base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ZmI0sZGAUNXUfMWboWwi4LcfpoVUYldyN6Oe0oJ5cCsHDU/LlRq8nQKPXhYLOx36QYSW9bNIb1vvRrD6K7Llgw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.3.2.tgz",
+      "integrity": "sha512-Q2Xn2/vQHRGLRXhQ5+BSLwhHkR3JVflxVKywH0Q6fVoAiUE8fFYL2pE5/l2ZiOiBDfA8qUqRnSxln4G/NFz1Sg==",
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -3190,9 +3189,10 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
-      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -3281,9 +3281,10 @@
       }
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+      "license": "MIT"
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
@@ -11095,6 +11096,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
@@ -15672,14 +15674,6 @@
         }
       }
     },
-    "@girder/oauth-client": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@girder/oauth-client/-/oauth-client-0.7.7.tgz",
-      "integrity": "sha512-BWkF4tAzUVWtw8p8KdVj7MAusgf2VO7LlhRSN0SVfCk4pTYqneT3S3wFoK1yqPKeiif4MalFT6YLpIygVicn5Q==",
-      "requires": {
-        "@openid/appauth": "^1.3.0"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -15696,14 +15690,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
-    },
-    "@isic/client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@isic/client/-/client-0.6.2.tgz",
-      "integrity": "sha512-iuJ8A35i+rzagV7QJ8VA9k7LShr1m8U1zGCu1uL405ABHGuPH6K9YicYcOT+AECzpFFwvH5bQm6atEzlh2/djQ==",
-      "requires": {
-        "@girder/oauth-client": "^0.7.7"
-      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -16272,28 +16258,36 @@
       }
     },
     "@openid/appauth": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@openid/appauth/-/appauth-1.3.1.tgz",
-      "integrity": "sha512-e54kpi219wES2ijPzeHe1kMnT8VKH8YeTd1GAn9BzVBmutz3tBgcG1y8a4pziNr4vNjFnuD4W446Ua7ELnNDiA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@openid/appauth/-/appauth-1.3.2.tgz",
+      "integrity": "sha512-NoOejniaqzOEbHg3RcBZtTriYqhqpQFgTC4lDNaRbgRCnpz6n8PlxWlCbh2N1K5qKawfxRP29/Wiho3FrXQ3Qw==",
       "requires": {
-        "@types/base64-js": "^1.3.0",
-        "@types/jquery": "^3.5.5",
+        "@types/base64-js": "^1.3.2",
+        "@types/jquery": "^3.5.29",
         "base64-js": "^1.5.1",
-        "follow-redirects": "^1.13.3",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "opener": "^1.5.2"
       },
       "dependencies": {
         "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+          "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@resonant/oauth-client": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@resonant/oauth-client/-/oauth-client-1.0.2.tgz",
+      "integrity": "sha512-P7mPkqtaUFGxK8Gb8oQXZHhvUGKgsxDzdnBgODUSoACwZj2uDmYrUIKEjnKoIYTlLLpeaxZE3yULl3RtJu0teg==",
+      "requires": {
+        "@openid/appauth": "^1.3.2"
       }
     },
     "@sinonjs/commons": {
@@ -16362,9 +16356,9 @@
       }
     },
     "@types/base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ZmI0sZGAUNXUfMWboWwi4LcfpoVUYldyN6Oe0oJ5cCsHDU/LlRq8nQKPXhYLOx36QYSW9bNIb1vvRrD6K7Llgw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.3.2.tgz",
+      "integrity": "sha512-Q2Xn2/vQHRGLRXhQ5+BSLwhHkR3JVflxVKywH0Q6fVoAiUE8fFYL2pE5/l2ZiOiBDfA8qUqRnSxln4G/NFz1Sg=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -16482,9 +16476,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
-      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
       "requires": {
         "@types/sizzle": "*"
       }
@@ -16573,9 +16567,9 @@
       }
     },
     "@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w=="
     },
     "@types/sockjs": {
       "version": "0.3.33",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@isic/client": "^0.6.2",
+    "@resonant/oauth-client": "^1.0.2",
     "aws-sdk": "^2.910.0",
     "axios": "^1.6.1",
     "core-js": "^3.38.0",

--- a/sources/services/auth.js
+++ b/sources/services/auth.js
@@ -1,4 +1,4 @@
-import IsicClient from "@isic/client";
+import OauthClient from "@resonant/oauth-client";
 import {AxiosError} from "axios";
 
 import constants from "../constants";
@@ -15,9 +15,9 @@ import ajax from "./ajaxActions";
 
 const ISIC_CLIENT_ID = process.env.ISIC_CLIENT_ID;
 const AUTHORIZATION_SERVER = process.env.ISIC_AUTHORIZATION_SERVER;
-const client = new IsicClient(
+const client = new OauthClient(
+	new URL(`${AUTHORIZATION_SERVER}/oauth/`),
 	ISIC_CLIENT_ID,
-	AUTHORIZATION_SERVER
 );
 
 class OAuthISIC {


### PR DESCRIPTION
The library `@isic/client` is being retired, in favor of directly using the `@resonant/oauth-client` library which it depended on.