### PR TITLE
Rename application to "isic-gallery"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-ISIC App
-===================
+# ISIC Gallery
+An interactive image gallery to query and display the ISIC Archive.
 
+## Development
 ### Building for production
 - Set the environment variables:
   - `ISIC_NEW_API_URL` to the absolute URL of the ISIC API root
@@ -24,7 +25,6 @@ ISIC App
 - Configure the directory at `codebase/sources/filesForDownload` to be served with the HTTP `Content-Disposition: attachment` header
 
 ### How to run for development
-
 - set ```devHost``` and ```devPort``` in ```appconfig.json```.
 - set the environment variables.
 - if you start first time you should run ```npm run build```. This command moves static files(images, libs, fonts) to ```codebase``` folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "isic-app",
+  "name": "isic-gallery",
   "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "isic-app",
+      "name": "isic-gallery",
       "version": "2.4.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "isic-app",
+  "name": "isic-gallery",
   "version": "2.4.1",
-  "description": "ISIC full app",
+  "description": "An interactive image gallery to query and display the ISIC Archive.",
   "main": "sources/app.js",
   "scripts": {
     "test": "jest --config=test/config/jest.config.js --no-cache",


### PR DESCRIPTION
This name better describes the purpose of this application.

Once this is merged, I also want to rename this repository to `isic-gallery` (GitHub will automatically keep a redirect from the old name and URL).